### PR TITLE
Fix #3: Bugfix/resolving failed in anonymous class

### DIFF
--- a/.github/workflows/create_github_release.yml
+++ b/.github/workflows/create_github_release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v5.0.1
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/formatting_check.yml
+++ b/.github/workflows/formatting_check.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v5.0.1
         with:
           fetch-depth: "0"
       - name: Set up JDK 11
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v5.0.1
         with:
           fetch-depth: "0"
       - name: Set up JDK 11

--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       ## Checkout the current version of the code from the repo.
       - name: Checkout latest code
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v5.0.1
         with:
           fetch-depth: "0"
 

--- a/.github/workflows/prepare_release_changelog.yml
+++ b/.github/workflows/prepare_release_changelog.yml
@@ -15,7 +15,7 @@ jobs:
 
       # Check out current repository
       - name: Fetch Sources
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v5.0.1
 
       # Setup Java 11 environment for the next steps
       - name: Setup Java

--- a/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootTest.java
+++ b/javaparser-core-testing/src/test/java/com/github/javaparser/utils/SourceRootTest.java
@@ -190,10 +190,8 @@ class SourceRootTest {
     }
 
     @Test
-    void saveAllPreservesAbsolutePaths(@TempDir Path tmp) throws Exception {
-        Path oldRoot = tmp.resolve("old");
-        Path newRoot = tmp.resolve("new");
-        Files.createDirectories(oldRoot);
+    void saveAllPreservesAbsolutePaths(@TempDir Path oldRoot, @TempDir Path newRoot, @TempDir Path absDir)
+            throws Exception {
 
         SourceRoot sr = new SourceRoot(oldRoot);
 
@@ -205,8 +203,7 @@ class SourceRootTest {
         assertFalse(Files.exists(expectedRelativeTarget.getParent()));
 
         // absolute key -> remains at absolute path
-        Path absPath = tmp.resolve("abs/X.java").toAbsolutePath();
-        Files.createDirectories(absPath.getParent());
+        Path absPath = absDir.resolve("X.java").toAbsolutePath();
         CompilationUnit cuAbs = StaticJavaParser.parse("package abs; class X {}");
         cuAbs.setStorage(absPath, StandardCharsets.UTF_8);
         sr.add(cuAbs);

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
@@ -471,21 +471,50 @@ public class SourceRoot {
     }
 
     /**
-     * Save all previously parsed files back to a new path.
-     * @param root the root of the java packages
-     * @param encoding the encoding to use while saving the file
+     * Saves all cached compilation units to the specified root directory.
+     *
+     * Path resolution follows java.nio.file.Path.resolve semantics:
+     * - Relative paths are resolved against the provided root.
+     * - Absolute paths remain unchanged (only normalized).
+     *
+     * @param root the destination root directory
+     * @param encoding the character encoding used when writing files
+     * @return this SourceRoot instance
+     * @throws NullPointerException if root is null
      */
     public SourceRoot saveAll(Path root, Charset encoding) {
         assertNotNull(root);
         Log.info("Saving all files (%s) to %s", cache::size, () -> root);
-        for (Map.Entry<Path, ParseResult<CompilationUnit>> cu : cache.entrySet()) {
-            final Path path = root.resolve(cu.getKey());
-            if (cu.getValue().getResult().isPresent()) {
-                Log.trace("Saving %s", () -> path);
-                save(cu.getValue().getResult().get(), path, encoding);
-            }
+
+        for (Map.Entry<Path, ParseResult<CompilationUnit>> e : cache.entrySet()) {
+            final Path target = resolvePath(root, e.getKey());
+            e.getValue().getResult().ifPresent(cu -> {
+                Log.trace("Saving %s", () -> target);
+                save(cu, target, encoding);
+            });
         }
         return this;
+    }
+
+    /**
+     * Resolves and normalizes a cached path using java.nio.file.Path.resolve semantics.
+     *
+     * Rules:
+     * - If cachedPath is relative, it is resolved under newRoot.
+     * - If cachedPath is absolute, it is returned unchanged (only normalized).
+     *
+     * @param newRoot the root directory used for resolution
+     * @param cachedPath the original cached path (relative or absolute)
+     * @return the resolved and normalized target path
+     * @throws NullPointerException if either argument is null
+     */
+    Path resolvePath(Path newRoot, Path cachedPath) {
+        if (newRoot == null || cachedPath == null) {
+            throw new NullPointerException("newRoot/cachedPath must not be null");
+        }
+        return cachedPath.isAbsolute()
+                ? cachedPath.normalize()
+                : newRoot.resolve(cachedPath).normalize();
     }
 
     /**

--- a/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/utils/SourceRoot.java
@@ -485,7 +485,6 @@ public class SourceRoot {
     public SourceRoot saveAll(Path root, Charset encoding) {
         assertNotNull(root);
         Log.info("Saving all files (%s) to %s", cache::size, () -> root);
-
         for (Map.Entry<Path, ParseResult<CompilationUnit>> e : cache.entrySet()) {
             final Path target = resolvePath(root, e.getKey());
             e.getValue().getResult().ifPresent(cu -> {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -23,9 +23,7 @@ package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.resolution.Context;
 import com.github.javaparser.resolution.MethodUsage;

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserClassDeclaration.java
@@ -408,13 +408,7 @@ public class JavaParserClassDeclaration extends AbstractClassDeclaration
 
     @Override
     public Set<ResolvedMethodDeclaration> getDeclaredMethods() {
-        Set<ResolvedMethodDeclaration> methods = new HashSet<>();
-        for (BodyDeclaration<?> member : wrappedNode.getMembers()) {
-            if (member instanceof MethodDeclaration) {
-                methods.add(new JavaParserMethodDeclaration((MethodDeclaration) member, typeSolver));
-            }
-        }
-        return methods;
+        return javaParserTypeAdapter.getDeclaredMethods();
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -23,7 +23,6 @@ package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.resolution.Context;

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserEnumDeclaration.java
@@ -78,14 +78,7 @@ public class JavaParserEnumDeclaration extends AbstractTypeDeclaration
 
     @Override
     public Set<ResolvedMethodDeclaration> getDeclaredMethods() {
-        Set<ResolvedMethodDeclaration> methods = new HashSet<>();
-        for (BodyDeclaration<?> member : wrappedNode.getMembers()) {
-            if (member instanceof com.github.javaparser.ast.body.MethodDeclaration) {
-                methods.add(new JavaParserMethodDeclaration(
-                        (com.github.javaparser.ast.body.MethodDeclaration) member, typeSolver));
-            }
-        }
-        return methods;
+        return javaParserTypeAdapter.getDeclaredMethods();
     }
 
     public Context getContext() {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -135,8 +135,7 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration
     public List<ResolvedReferenceType> getInterfacesExtended() {
         List<ResolvedReferenceType> interfaces = new ArrayList<>();
         for (ClassOrInterfaceType t : wrappedNode.getExtendedTypes()) {
-            interfaces.add(new ReferenceTypeImpl(
-                    solveType(t.getName().getId()).getCorrespondingDeclaration().asInterface()));
+            interfaces.add(toReferenceType(t));
         }
         return interfaces;
     }

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -70,14 +70,7 @@ public class JavaParserInterfaceDeclaration extends AbstractTypeDeclaration
 
     @Override
     public Set<ResolvedMethodDeclaration> getDeclaredMethods() {
-        Set<ResolvedMethodDeclaration> methods = new HashSet<>();
-        for (BodyDeclaration<?> member : wrappedNode.getMembers()) {
-            if (member instanceof com.github.javaparser.ast.body.MethodDeclaration) {
-                methods.add(new JavaParserMethodDeclaration(
-                        (com.github.javaparser.ast.body.MethodDeclaration) member, typeSolver));
-            }
-        }
-        return methods;
+        return javaParserTypeAdapter.getDeclaredMethods();
     }
 
     public Context getContext() {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserInterfaceDeclaration.java
@@ -23,7 +23,6 @@ package com.github.javaparser.symbolsolver.javaparsermodel.declarations;
 
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.resolution.Context;

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeAdapter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/declarations/JavaParserTypeAdapter.java
@@ -31,10 +31,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.nodeTypes.NodeWithTypeParameters;
 import com.github.javaparser.ast.type.TypeParameter;
 import com.github.javaparser.resolution.TypeSolver;
-import com.github.javaparser.resolution.declarations.ResolvedAnnotationDeclaration;
-import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration;
-import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
-import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
+import com.github.javaparser.resolution.declarations.*;
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.model.typesystem.ReferenceTypeImpl;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
@@ -204,6 +201,19 @@ public class JavaParserTypeAdapter<
         return wrappedNode.getAnnotations().stream()
                 .map(annotation -> annotation.resolve())
                 .collect(Collectors.toSet());
+    }
+
+    /*
+     * Returns a set of the declared methods on this type
+     */
+    public Set<ResolvedMethodDeclaration> getDeclaredMethods() {
+        Set<ResolvedMethodDeclaration> methods = new HashSet<>();
+        for (BodyDeclaration<?> member : wrappedNode.getMembers()) {
+            if (member instanceof MethodDeclaration) {
+                methods.add(new JavaParserMethodDeclaration((MethodDeclaration) member, typeSolver));
+            }
+        }
+        return methods;
     }
 
     public Set<ResolvedReferenceTypeDeclaration> internalTypes() {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionClassDeclaration.java
@@ -200,7 +200,7 @@ public class ReflectionClassDeclaration extends AbstractClassDeclaration
 
     @Override
     public String toString() {
-        return "ReflectionClassDeclaration{" + "clazz=" + getId() + '}';
+        return getClass().getSimpleName() + "{" + "clazz=" + getId() + '}';
     }
 
     public ResolvedType getUsage(Node node) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionInterfaceDeclaration.java
@@ -114,7 +114,7 @@ public class ReflectionInterfaceDeclaration extends AbstractTypeDeclaration
 
     @Override
     public String toString() {
-        return "ReflectionInterfaceDeclaration{" + "clazz=" + clazz.getCanonicalName() + '}';
+        return getClass().getSimpleName() + "{" + "clazz=" + clazz.getCanonicalName() + '}';
     }
 
     public ResolvedType getUsage(Node node) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionMethodDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionMethodDeclaration.java
@@ -74,7 +74,7 @@ public class ReflectionMethodDeclaration implements ResolvedMethodDeclaration, T
 
     @Override
     public String toString() {
-        return "ReflectionMethodDeclaration{" + "method=" + method + '}';
+        return getClass().getSimpleName() + "{" + "method=" + method + '}';
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionParameterDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionParameterDeclaration.java
@@ -69,7 +69,7 @@ public class ReflectionParameterDeclaration implements ResolvedParameterDeclarat
 
     @Override
     public String toString() {
-        return "ReflectionParameterDeclaration{" + "type=" + type + ", name=" + name + '}';
+        return getClass().getSimpleName() + "{" + "type=" + type + ", name=" + name + '}';
     }
 
     @Override

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionRecordDeclaration.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionRecordDeclaration.java
@@ -205,7 +205,7 @@ public class ReflectionRecordDeclaration extends AbstractTypeDeclaration
 
     @Override
     public String toString() {
-        return "ReflectionClassDeclaration{" + "clazz=" + getId() + '}';
+        return getClass().getSimpleName() + "{" + "clazz=" + getId() + '}';
     }
 
     public ResolvedType getUsage(Node node) {

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionTypeParameter.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionTypeParameter.java
@@ -118,7 +118,7 @@ public class ReflectionTypeParameter implements ResolvedTypeParameterDeclaration
 
     @Override
     public String toString() {
-        return "ReflectionTypeParameter{" + "typeVariable=" + typeVariable + '}';
+        return getClass().getSimpleName() + "{" + "typeVariable=" + typeVariable + '}';
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4864Test.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/Issue4864Test.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2011, 2013-2023 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.javaparser.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.reflectionmodel.*;
+import java.lang.reflect.Method;
+import java.lang.reflect.TypeVariable;
+import org.junit.jupiter.api.Test;
+
+public class Issue4864Test {
+    private final TypeSolver typeSolver = null;
+
+    @Test
+    void testReflectionInterfaceDeclarationToString() {
+        ReflectionInterfaceDeclaration decl = new ReflectionInterfaceDeclaration(Runnable.class, typeSolver);
+        String output = decl.toString();
+
+        assertTrue(output.contains("ReflectionInterfaceDeclaration"));
+        assertTrue(output.contains("clazz=java.lang.Runnable"));
+    }
+
+    @Test
+    void testReflectionClassDeclarationToString() {
+        ReflectionClassDeclaration decl = new ReflectionClassDeclaration(String.class, typeSolver);
+        String output = decl.toString();
+
+        assertTrue(output.contains("ReflectionClassDeclaration"));
+        assertTrue(output.contains("clazz="));
+        assertTrue(output.contains("java.lang.String"));
+    }
+
+    @Test
+    void testReflectionParameterDeclarationToString() {
+        ReflectionParameterDeclaration decl =
+                new ReflectionParameterDeclaration(String.class, String.class, typeSolver, false, "param1");
+        String output = decl.toString();
+
+        assertTrue(output.contains("ReflectionParameterDeclaration"));
+        assertTrue(output.contains("type=class java.lang.String"));
+        assertTrue(output.contains("name=param1"));
+    }
+
+    @Test
+    void testReflectionTypeParameterToString() {
+        TypeVariable<Class<Comparable>> typeVar = Comparable.class.getTypeParameters()[0];
+        ReflectionTypeParameter param = new ReflectionTypeParameter(typeVar, true, typeSolver);
+        String output = param.toString();
+
+        assertTrue(output.contains("ReflectionTypeParameter"));
+        assertTrue(output.contains("typeVariable="));
+        assertTrue(output.contains("T"));
+    }
+
+    @Test
+    void testReflectionMethodDeclarationToString() throws NoSuchMethodException {
+        Method method = String.class.getMethod("substring", int.class, int.class);
+        ReflectionMethodDeclaration decl = new ReflectionMethodDeclaration(method, typeSolver);
+        String output = decl.toString();
+
+        assertTrue(output.contains("ReflectionMethodDeclaration"));
+        assertTrue(output.contains("method=public java.lang.String java.lang.String.substring(int,int)"));
+    }
+}

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionRecordDeclarationTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/reflectionmodel/ReflectionRecordDeclarationTest.java
@@ -396,4 +396,16 @@ class ReflectionRecordDeclarationTest extends AbstractSymbolResolutionTest {
                 Navigator.findMethodCall(cu.getResult().get(), "value").get();
         assertEquals("java.lang.Integer", valueCall.calculateResolvedType().describe());
     }
+
+    @Test
+    @EnabledForJreRange(min = org.junit.jupiter.api.condition.JRE.JAVA_17)
+    void testToStringShouldUseCorrectClassName() {
+        ReflectionRecordDeclaration decl = (ReflectionRecordDeclaration) typeSolver.solveType("box.Box");
+
+        String result = decl.toString();
+
+        assertTrue(
+                result.contains("ReflectionRecordDeclaration"),
+                "Expected 'ReflectionRecordDeclaration' in toString(), but got: " + result);
+    }
 }

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnonymousOuterLookupTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/AnonymousOuterLookupTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2015-2016 Federico Tomassetti
+ * Copyright (C) 2017-2024 The JavaParser Team.
+ *
+ * This file is part of JavaParser.
+ *
+ * JavaParser can be used either under the terms of
+ * a) the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ * b) the terms of the Apache License
+ *
+ * You should have received a copy of both licenses in LICENCE.LGPL and
+ * LICENCE.APACHE. Please refer to those files for details.
+ *
+ * JavaParser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+package com.github.javaparser.symbolsolver.resolution;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.SymbolResolver;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.symbolsolver.JavaSymbolSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JarTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+
+class AnonymousOuterLookupTest {
+
+    private CompilationUnit parse(String code) {
+        CombinedTypeSolver solver = new CombinedTypeSolver(new ReflectionTypeSolver());
+        ParserConfiguration cfg = new ParserConfiguration().setSymbolResolver(new JavaSymbolSolver(solver));
+        return new JavaParser(cfg).parse(code).getResult().orElseThrow(() -> new AssertionError("Parse failed"));
+    }
+
+    private static MethodCallExpr firstCallNamed(CompilationUnit cu, String name) {
+        return cu.findAll(MethodCallExpr.class).stream()
+                .filter(e -> e.getNameAsString().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("call '" + name + "' not found"));
+    }
+
+    // --- Positives (instance context): should resolve via enclosing instance ---
+
+    /**
+     * Anonymous class inside instance method: unqualified call resolves to outer instance method.
+     */
+    @Test
+    void resolves_in_instance_method_via_anonymous() {
+        String code = ""
+                + "import java.util.concurrent.Callable;\n"
+                + "class T {\n"
+                + "  String m(String k){ return \"ok\"; }\n"
+                + "  String go(String key) throws Exception {\n"
+                + "    return new Callable<String>(){\n"
+                + "      public String call(){ return m(key); }\n"
+                + "    }.call();\n"
+                + "  }\n"
+                + "}\n";
+        CompilationUnit cu = parse(code);
+        MethodCallExpr call = firstCallNamed(cu, "m");
+        ResolvedMethodDeclaration r = call.resolve();
+        assertEquals("T", r.declaringType().getQualifiedName());
+        assertEquals("m", r.getName());
+        assertEquals("java.lang.String", r.getParam(0).describeType());
+    }
+
+    /**
+     * Multiple enclosing instances: walk out to A#m.
+     */
+    @Test
+    void resolves_through_multiple_enclosing_instances() {
+        String code = ""
+                + "class A {\n"
+                + "  String m(String s){ return \"A\"; }\n"
+                + "  class B {\n"
+                + "    class C {\n"
+                + "      String go(String k){ class D{ String x(){ return m(k); } } return new D().x(); }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}\n";
+        CompilationUnit cu = parse(code);
+        MethodCallExpr call = firstCallNamed(cu, "m");
+        ResolvedMethodDeclaration r = call.resolve();
+        assertEquals("A", r.declaringType().getQualifiedName());
+    }
+
+    // --- Negatives (static context): must NOT resolve without explicit receiver ---
+
+    /**
+     * Anonymous class inside static method: unqualified call must throw.
+     */
+    @Test
+    void does_not_resolve_in_static_method_anonymous_unqualified() {
+        String code = ""
+                + "import java.util.concurrent.Callable;\n"
+                + "class T {\n"
+                + "  String m(String k){ return \"ok\"; }\n"
+                + "  static String go(String key) throws Exception {\n"
+                + "    return new Callable<String>(){\n"
+                + "      public String call(){ return m(key); }\n"
+                + "    }.call();\n"
+                + "  }\n"
+                + "}\n";
+        CompilationUnit cu = parse(code);
+        MethodCallExpr call = firstCallNamed(cu, "m");
+        assertThrows(RuntimeException.class, call::resolve); // UnsolvedSymbolException is a RuntimeException
+    }
+
+    /**
+     * Local class inside static method: unqualified call must throw.
+     */
+    @Test
+    void does_not_resolve_local_class_in_static_method() {
+        String code = ""
+                + "class T {\n"
+                + "  String m(String k){ return \"ok\"; }\n"
+                + "  static String go(String key) {\n"
+                + "    class L { String x(){ return m(key); } }\n"
+                + "    return new L().x();\n"
+                + "  }\n"
+                + "}\n";
+        CompilationUnit cu = parse(code);
+        MethodCallExpr call = firstCallNamed(cu, "m");
+        assertThrows(RuntimeException.class, call::resolve);
+    }
+
+    /**
+     * Lambda inside static method: unqualified call must throw.
+     */
+    @Test
+    void does_not_resolve_lambda_in_static_method() {
+        String code = ""
+                + "import java.util.function.Supplier;\n"
+                + "class T {\n"
+                + "  String m(String k){ return \"ok\"; }\n"
+                + "  static String go(String key) {\n"
+                + "    Supplier<String> s = () -> m(key);\n"
+                + "    return s.get();\n"
+                + "  }\n"
+                + "}\n";
+        CompilationUnit cu = parse(code);
+        MethodCallExpr call = firstCallNamed(cu, "m");
+        assertThrows(RuntimeException.class, call::resolve);
+    }
+
+    // --- Static with explicit receiver: should resolve ---
+
+    @Test
+    void resolves_in_static_with_explicit_receiver() {
+        String code = ""
+                + "class T {\n"
+                + "  String m(String k){ return \"ok\"; }\n"
+                + "  static String go(String key) {\n"
+                + "    return new T().m(key);\n"
+                + "  }\n"
+                + "}\n";
+        CompilationUnit cu = parse(code);
+        MethodCallExpr call = firstCallNamed(cu, "m");
+        ResolvedMethodDeclaration r = call.resolve();
+        assertEquals("T", r.declaringType().getQualifiedName());
+    }
+
+    @Test
+    void resolves_method_in_anonymous_class_with_guava_reflection_solver() throws Exception {
+        String code = ""
+                + "import com.google.common.cache.Cache;\n"
+                + "import com.google.common.cache.CacheBuilder;\n"
+                + "import java.util.concurrent.Callable;\n"
+                + "\n"
+                + "class TestClass {\n"
+                + "    Cache<String, String> cache = CacheBuilder.newBuilder().build(); // resolved as reflection or javassist declaration\n"
+                + "\n"
+                + "    String getByAnnoClass(String key) throws Exception {\n"
+                + "        return cache.get(key, new TraceCallable<>(new Callable<String>() {\n"
+                + "            @Override\n"
+                + "            public String call() {\n"
+                + "                return actuallyGet(key);\n"
+                + "            }\n"
+                + "        }));\n"
+                + "    }\n"
+                + "\n"
+                + "    String actuallyGet(String key) {\n"
+                + "        return null;\n"
+                + "    }\n"
+                + "\n"
+                + "    static class TraceCallable<T> implements Callable<T> {\n"
+                + "        private final Callable<T> target;\n"
+                + "\n"
+                + "        TraceCallable(Callable<T> target) {\n"
+                + "            this.target = target;\n"
+                + "        }\n"
+                + "\n"
+                + "        @Override\n"
+                + "        public T call() throws Exception {\n"
+                + "            return target.call();\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+
+        String m2Repo = System.getProperty("user.home") + "/.m2/repository/com/google/guava/guava";
+        String latestVersion = Files.list(Paths.get(m2Repo))
+                .filter(Files::isDirectory)
+                .map(p -> p.getFileName().toString())
+                .sorted()
+                .reduce((first, second) -> second)
+                .orElseThrow(() -> new RuntimeException("Guava not found in ~/.m2 repository"));
+        String guavaJarPath = m2Repo + "/" + latestVersion + "/guava-" + latestVersion + ".jar";
+
+        SymbolResolver symbolResolver = new JavaSymbolSolver(
+                new CombinedTypeSolver(new ReflectionTypeSolver(), new JarTypeSolver(guavaJarPath)));
+        ParserConfiguration config = new ParserConfiguration().setSymbolResolver(symbolResolver);
+        CompilationUnit cu = new JavaParser(config).parse(code).getResult().get();
+
+        cu.findAll(MethodCallExpr.class).stream()
+                .filter(e -> "actuallyGet".equals(e.getNameAsString()))
+                .forEach(expr -> {
+                    try {
+                        System.out.println(">>> resolving MethodCallExpr: " + expr);
+                        ResolvedMethodDeclaration rmd = expr.resolve();
+                        System.out.println("<<< MethodDeclaration resolved: " + rmd);
+                        assertEquals("TestClass", rmd.declaringType().getClassName());
+                        assertEquals("actuallyGet", rmd.getName());
+                        assertEquals(1, rmd.getNumberOfParams());
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        fail("Resolution failed: " + e.getMessage());
+                    }
+                });
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <byte-buddy.version>1.17.8</byte-buddy.version>
+        <byte-buddy.version>1.18.0</byte-buddy.version>
         <argLine>-javaagent:'${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar'</argLine>
         <build.timestamp>2025-10-04T00:00:00Z</build.timestamp>
         <jacoco.javaagent/>

--- a/pom.xml
+++ b/pom.xml
@@ -445,7 +445,7 @@
 			<dependency>
 				<groupId>org.junit</groupId>
 				<artifactId>junit-bom</artifactId>
-				<version>5.14.0</version>
+				<version>5.14.1</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.4.2</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <!-- Plugin for preparing and performing a release (to sonatype central publishing portal / maven central). -->

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
                     <!-- Plugin for preparing and performing a release (to sonatype central publishing portal / maven central). -->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.2.0</version>
                     <configuration>
                         <!-- When updating versions during release, synchronise versions of sub-modules with the parent-pom. -->
                         <autoVersionSubmodules>true</autoVersionSubmodules>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <byte-buddy.version>1.18.0</byte-buddy.version>
+        <byte-buddy.version>1.18.1</byte-buddy.version>
         <argLine>-javaagent:'${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar'</argLine>
         <build.timestamp>2025-10-04T00:00:00Z</build.timestamp>
         <jacoco.javaagent/>

--- a/pom.xml
+++ b/pom.xml
@@ -434,7 +434,7 @@
 			<dependency>
 				<groupId>org.checkerframework</groupId>
 				<artifactId>checker-qual</artifactId>
-				<version>3.51.1</version>
+				<version>3.52.0</version>
 			</dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
###Fixes
Fixes #3.
(Related upstream issue: javaparser#4803)

### Details
- Updated solve() method to still walk up parent nodes if scope is invalid
- Added a new method IsInsideStaticMember() which checks static context for the node
- Added tests in `AnonymousOuterLookupTest.java` replicating issue bugs